### PR TITLE
feat: bootstrap discord bot with auto update flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+DISCORD_TOKEN=your-discord-bot-token
+APPLICATION_ID=your-application-id
+GUILD_ID=
+OWNER_IDS=
+UPDATE_CHANNEL_ID=channel-id-for-updates
+GITHUB_REPOSITORY=owner/repository
+GITHUB_BRANCH=main
+GITHUB_TOKEN=
+UPDATE_CHECK_INTERVAL_MS=1800000

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+.env
+dist
+npm-debug.log*
+.yarn*
+.pnpm*
+.DS_Store
+data/update-state.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,53 @@
-# Ascenders
+# Ascenders Bot
+
+A modular Discord.js bot for the Ascenders project. This initial iteration implements:
+
+- A `/ping` slash command to check the bot latency.
+- An automated GitHub update workflow that posts approval prompts in a designated channel and, upon owner approval, pulls the latest code, installs dependencies, and rebuilds the project.
+
+## Getting Started
+
+1. **Install dependencies**
+
+   ```bash
+   npm install
+   ```
+
+2. **Configure environment**
+
+   Copy `.env.example` to `.env` and fill in the values:
+
+   ```env
+   DISCORD_TOKEN=your-discord-bot-token
+   APPLICATION_ID=your-application-id
+   OWNER_IDS=comma,separated,discord,user,ids
+   UPDATE_CHANNEL_ID=channel-id-for-updates
+   GITHUB_REPOSITORY=owner/repository
+   GITHUB_BRANCH=main
+   ```
+
+3. **Build and run**
+
+   ```bash
+   npm run build
+   npm start
+   ```
+
+   During development you can run:
+
+   ```bash
+   npm run dev
+   ```
+
+## Update Workflow
+
+- The bot periodically checks the configured GitHub repository for new commits on the selected branch.
+- When a new commit is detected, it posts an embed in the configured channel with **Approve** and **Reject** buttons. Only allowed owners can approve.
+- Approving runs `git pull`, `npm install`, and `npm run build`. Results are returned to the reviewer and the prompt embed is updated to reflect success or failure.
+- Rejecting closes the prompt without applying the update.
+
+## Future Work
+
+- Add giveaway, moderation, reminder, and logging systems.
+- Expand the command framework and help menu.
+- Integrate MongoDB persistence.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "ascenders",
+  "version": "1.0.0",
+  "description": "Discord bot with auto-update system",
+  "main": "dist/index.js",
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "dev": "ts-node-esm src/index.ts"
+  },
+  "keywords": [
+    "discord",
+    "bot"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "discord.js": "^14.14.1",
+    "dotenv": "^16.4.5"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.7",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.5"
+  }
+}

--- a/src/commands/ping.ts
+++ b/src/commands/ping.ts
@@ -1,0 +1,13 @@
+import type { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
+import { SlashCommandBuilder as Builder } from 'discord.js';
+
+export const data: SlashCommandBuilder = new Builder()
+  .setName('ping')
+  .setDescription('Check if the bot is online.');
+
+export async function execute(interaction: ChatInputCommandInteraction) {
+  const sent = await interaction.reply({ content: 'Pinging...', fetchReply: true });
+  const latency = sent.createdTimestamp - interaction.createdTimestamp;
+  const websocketPing = interaction.client.ws.ping;
+  await interaction.editReply(`Pong! Latency: ${latency}ms. WebSocket: ${websocketPing}ms.`);
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,52 @@
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const requiredEnv = [
+  'DISCORD_TOKEN',
+  'APPLICATION_ID',
+  'UPDATE_CHANNEL_ID',
+  'GITHUB_REPOSITORY'
+] as const;
+
+type RequiredEnv = (typeof requiredEnv)[number];
+
+type Config = {
+  discordToken: string;
+  applicationId: string;
+  guildId?: string;
+  ownerIds: string[];
+  updateChannelId: string;
+  githubRepository: { owner: string; repo: string };
+  githubBranch: string;
+  githubToken?: string;
+  updateCheckIntervalMs: number;
+};
+
+function ensureEnvValue(key: RequiredEnv): string {
+  const value = process.env[key];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${key}`);
+  }
+  return value;
+}
+
+function parseRepositorySlug(slug: string): { owner: string; repo: string } {
+  const [owner, repo] = slug.split('/');
+  if (!owner || !repo) {
+    throw new Error('GITHUB_REPOSITORY must be in the form "owner/repo"');
+  }
+  return { owner, repo };
+}
+
+export const config: Config = {
+  discordToken: ensureEnvValue('DISCORD_TOKEN'),
+  applicationId: ensureEnvValue('APPLICATION_ID'),
+  guildId: process.env.GUILD_ID,
+  ownerIds: process.env.OWNER_IDS?.split(',').map((id) => id.trim()).filter(Boolean) ?? [],
+  updateChannelId: ensureEnvValue('UPDATE_CHANNEL_ID'),
+  githubRepository: parseRepositorySlug(ensureEnvValue('GITHUB_REPOSITORY')),
+  githubBranch: process.env.GITHUB_BRANCH ?? 'main',
+  githubToken: process.env.GITHUB_TOKEN,
+  updateCheckIntervalMs: Number(process.env.UPDATE_CHECK_INTERVAL_MS ?? 1000 * 60 * 30)
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,71 @@
+import { Client, Collection, Events, GatewayIntentBits, Interaction, REST, Routes } from 'discord.js';
+import { config } from './config.js';
+import * as pingCommand from './commands/ping.js';
+import type { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
+import { UpdateService } from './services/updateService.js';
+
+type CommandModule = {
+  data: SlashCommandBuilder;
+  execute: (interaction: ChatInputCommandInteraction) => Promise<void>;
+};
+
+const commands = new Collection<string, CommandModule>();
+commands.set(pingCommand.data.name, pingCommand);
+
+const client = new Client({ intents: [GatewayIntentBits.Guilds] });
+const rest = new REST({ version: '10' }).setToken(config.discordToken);
+const updateService = new UpdateService(client);
+
+async function registerCommands() {
+  const body = commands.map((command) => command.data.toJSON());
+
+  if (config.guildId) {
+    await rest.put(Routes.applicationGuildCommands(config.applicationId, config.guildId), { body });
+    console.log(`Registered ${body.length} guild command(s).`);
+  } else {
+    await rest.put(Routes.applicationCommands(config.applicationId), { body });
+    console.log(`Registered ${body.length} global command(s).`);
+  }
+}
+
+client.once(Events.ClientReady, async (readyClient) => {
+  console.log(`Logged in as ${readyClient.user.tag}`);
+  await registerCommands();
+  await updateService.init();
+});
+
+client.on(Events.InteractionCreate, async (interaction: Interaction) => {
+  try {
+    if (interaction.isChatInputCommand()) {
+      const command = commands.get(interaction.commandName);
+      if (!command) {
+        await interaction.reply({ content: 'Command not found.', ephemeral: true });
+        return;
+      }
+      await command.execute(interaction);
+    } else if (interaction.isButton()) {
+      await updateService.handleInteraction(interaction);
+    }
+  } catch (error) {
+    console.error('Error handling interaction', error);
+    if (interaction.isRepliable()) {
+      const content = 'There was an error while executing this interaction.';
+      if (interaction.deferred || interaction.replied) {
+        await interaction.editReply({ content });
+      } else {
+        await interaction.reply({ content, ephemeral: true });
+      }
+    }
+  }
+});
+
+client.login(config.discordToken).catch((error) => {
+  console.error('Failed to login to Discord', error);
+  process.exit(1);
+});
+
+process.on('SIGINT', async () => {
+  await updateService.destroy();
+  client.destroy();
+  process.exit(0);
+});

--- a/src/services/updateService.ts
+++ b/src/services/updateService.ts
@@ -1,0 +1,285 @@
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonInteraction,
+  ButtonStyle,
+  Client,
+  EmbedBuilder,
+  GuildTextBasedChannel
+} from 'discord.js';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { spawn } from 'child_process';
+import { config } from '../config.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const stateFilePath = path.resolve(__dirname, '../../data/update-state.json');
+
+interface UpdateState {
+  deployedSha?: string;
+  pendingSha?: string;
+}
+
+interface GitHubCommitResponse {
+  sha: string;
+  html_url: string;
+  commit: {
+    message: string;
+    author: {
+      name: string;
+      date: string;
+    };
+  };
+}
+
+export class UpdateService {
+  private state: UpdateState = {};
+  private interval?: NodeJS.Timeout;
+  private pendingMessages = new Map<string, string>();
+
+  constructor(private readonly client: Client) {}
+
+  async init() {
+    await this.ensureStateFile();
+    await this.loadState();
+    await this.checkForUpdates();
+    this.interval = setInterval(() => {
+      this.checkForUpdates().catch((error) => {
+        console.error('Failed to check for updates', error);
+      });
+    }, config.updateCheckIntervalMs).unref?.();
+  }
+
+  async destroy() {
+    if (this.interval) {
+      clearInterval(this.interval);
+    }
+  }
+
+  async handleInteraction(interaction: ButtonInteraction) {
+    const [prefix, action, sha] = interaction.customId.split(':');
+    if (prefix !== 'update') {
+      return;
+    }
+
+    if (config.ownerIds.length > 0 && !config.ownerIds.includes(interaction.user.id)) {
+      await interaction.reply({
+        content: 'You do not have permission to approve updates.',
+        ephemeral: true
+      });
+      return;
+    }
+
+    if (sha !== this.state.pendingSha) {
+      await interaction.reply({
+        content: 'This update request is no longer active.',
+        ephemeral: true
+      });
+      return;
+    }
+
+    if (action === 'approve') {
+      await this.handleApprove(interaction, sha);
+    } else if (action === 'reject') {
+      await this.handleReject(interaction, sha);
+    }
+  }
+
+  private async handleApprove(interaction: ButtonInteraction, sha: string) {
+    await interaction.deferReply({ ephemeral: true });
+    try {
+      const result = await this.performUpdate();
+      await interaction.editReply({
+        content: `Update to commit ${sha} completed.\n${result}`
+      });
+      this.state.deployedSha = sha;
+      this.state.pendingSha = undefined;
+      await this.persistState();
+      const message = await interaction.message.fetch();
+      await message.edit({
+        components: [],
+        embeds: [
+          EmbedBuilder.from(message.embeds[0] ?? {})
+            .setColor(0x57f287)
+            .setFooter({ text: 'Update applied successfully.' })
+        ]
+      });
+    } catch (error) {
+      console.error('Update failed', error);
+      await interaction.editReply({
+        content: `Update failed: ${(error as Error).message}`
+      });
+      const message = await interaction.message.fetch();
+      await message.edit({
+        components: [],
+        embeds: [
+          EmbedBuilder.from(message.embeds[0] ?? {})
+            .setColor(0xed4245)
+            .setFooter({ text: 'Update failed. See response thread for details.' })
+        ]
+      });
+    }
+  }
+
+  private async handleReject(interaction: ButtonInteraction, sha: string) {
+    await interaction.update({
+      content: `Update ${sha} rejected by ${interaction.user.tag}.`,
+      embeds: [],
+      components: []
+    });
+    this.state.pendingSha = undefined;
+    await this.persistState();
+  }
+
+  private async ensureStateFile() {
+    try {
+      await fs.access(stateFilePath);
+    } catch {
+      await fs.mkdir(path.dirname(stateFilePath), { recursive: true });
+      await fs.writeFile(stateFilePath, JSON.stringify({}, null, 2), 'utf8');
+    }
+  }
+
+  private async loadState() {
+    try {
+      const raw = await fs.readFile(stateFilePath, 'utf8');
+      this.state = JSON.parse(raw) as UpdateState;
+    } catch (error) {
+      console.warn('Failed to read update state; starting fresh.', error);
+      this.state = {};
+    }
+  }
+
+  private async persistState() {
+    await fs.writeFile(stateFilePath, JSON.stringify(this.state, null, 2), 'utf8');
+  }
+
+  private async checkForUpdates() {
+    const latest = await this.fetchLatestCommit();
+    if (!latest) {
+      return;
+    }
+
+    if (latest.sha === this.state.deployedSha || latest.sha === this.state.pendingSha) {
+      return;
+    }
+
+    await this.notifyPendingUpdate(latest);
+    this.state.pendingSha = latest.sha;
+    await this.persistState();
+  }
+
+  private async fetchLatestCommit(): Promise<GitHubCommitResponse | null> {
+    const { owner, repo } = config.githubRepository;
+    const url = `https://api.github.com/repos/${owner}/${repo}/commits/${config.githubBranch}`;
+    const response = await fetch(url, {
+      headers: {
+        'User-Agent': 'AscendersBot/1.0',
+        ...(config.githubToken ? { Authorization: `Bearer ${config.githubToken}` } : {})
+      }
+    });
+
+    if (response.status === 304) {
+      return null;
+    }
+
+    if (!response.ok) {
+      throw new Error(`GitHub API request failed with status ${response.status}`);
+    }
+
+    const data = (await response.json()) as GitHubCommitResponse;
+    return data;
+  }
+
+  private async notifyPendingUpdate(commit: GitHubCommitResponse) {
+    const channel = await this.resolveUpdateChannel();
+    if (!channel) {
+      console.warn('Update channel not found or not text-based.');
+      return;
+    }
+
+    const embed = new EmbedBuilder()
+      .setTitle('Pending Update Available')
+      .setDescription(commit.commit.message.split('\n')[0])
+      .addFields(
+        { name: 'Commit', value: `[${commit.sha.substring(0, 7)}](${commit.html_url})` },
+        { name: 'Author', value: commit.commit.author.name, inline: true },
+        { name: 'Date', value: new Date(commit.commit.author.date).toLocaleString(), inline: true }
+      )
+      .setColor(0xf1c40f)
+      .setTimestamp(new Date(commit.commit.author.date));
+
+    const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder()
+        .setCustomId(`update:approve:${commit.sha}`)
+        .setLabel('Approve Update')
+        .setStyle(ButtonStyle.Success),
+      new ButtonBuilder()
+        .setCustomId(`update:reject:${commit.sha}`)
+        .setLabel('Reject Update')
+        .setStyle(ButtonStyle.Danger)
+    );
+
+    const message = await channel.send({
+      content: config.ownerIds.length
+        ? `Update available. Only <@${config.ownerIds.join('>, <@')}> may approve.`
+        : 'Update available. Review and approve if you have permission.',
+      embeds: [embed],
+      components: [row]
+    });
+
+    this.pendingMessages.set(message.id, commit.sha);
+  }
+
+  private async resolveUpdateChannel(): Promise<GuildTextBasedChannel | null> {
+    const channel = await this.client.channels.fetch(config.updateChannelId);
+    if (!channel || !channel.isTextBased() || !('guildId' in channel)) {
+      return null;
+    }
+
+    return channel as GuildTextBasedChannel;
+  }
+
+  private async performUpdate(): Promise<string> {
+    const commands: Array<[string, string[]]> = [
+      ['git', ['pull', 'origin', config.githubBranch]],
+      ['npm', ['install']],
+      ['npm', ['run', 'build']]
+    ];
+
+    const outputs: string[] = [];
+
+    for (const [command, args] of commands) {
+      const { stdout, stderr } = await this.runCommand(command, args);
+      outputs.push(`$ ${command} ${args.join(' ')}\n${stdout}${stderr ? `\n${stderr}` : ''}`.trim());
+    }
+
+    return outputs.join('\n\n');
+  }
+
+  private runCommand(command: string, args: string[]) {
+    return new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
+      const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+      const stdout: Buffer[] = [];
+      const stderr: Buffer[] = [];
+
+      child.stdout.on('data', (chunk) => stdout.push(Buffer.from(chunk)));
+      child.stderr.on('data', (chunk) => stderr.push(Buffer.from(chunk)));
+
+      child.once('error', reject);
+      child.once('close', (code) => {
+        if (code === 0) {
+          resolve({ stdout: Buffer.concat(stdout).toString('utf8'), stderr: Buffer.concat(stderr).toString('utf8') });
+        } else {
+          reject(
+            new Error(
+              `${command} ${args.join(' ')} exited with code ${code}.\n${Buffer.concat(stderr).toString('utf8')}`
+            )
+          );
+        }
+      });
+    });
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "ESNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- scaffold a discord.js bot entry point with slash command registration and a `/ping` command
- add an automated GitHub update workflow that requests owner approval and runs pull/install/build when approved
- document setup steps and environment variables for the new bot structure

## Testing
- not run (dependency installation unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e5eeb775d0832fb9ff1a06314d85ac