### PR TITLE
Handle npm command resolution on Windows

### DIFF
--- a/src/services/updateService.ts
+++ b/src/services/updateService.ts
@@ -243,20 +243,31 @@ export class UpdateService {
   }
 
   private async performUpdate(): Promise<string> {
-    const commands: Array<[string, string[]]> = [
-      ['git', ['pull', 'origin', config.githubBranch]],
-      ['npm', ['install']],
-      ['npm', ['run', 'build']]
+    const commands: Array<{ command: string; args: string[] }> = [
+      { command: 'git', args: ['pull', 'origin', config.githubBranch] },
+      { command: 'npm', args: ['install'] },
+      { command: 'npm', args: ['run', 'build'] }
     ];
 
     const outputs: string[] = [];
 
-    for (const [command, args] of commands) {
-      const { stdout, stderr } = await this.runCommand(command, args);
-      outputs.push(`$ ${command} ${args.join(' ')}\n${stdout}${stderr ? `\n${stderr}` : ''}`.trim());
+    for (const { command, args } of commands) {
+      const resolvedCommand = this.resolveCommand(command);
+      const { stdout, stderr } = await this.runCommand(resolvedCommand, args);
+      outputs.push(
+        `$ ${command} ${args.join(' ')}\n${stdout}${stderr ? `\n${stderr}` : ''}`.trim()
+      );
     }
 
     return outputs.join('\n\n');
+  }
+
+  private resolveCommand(command: string) {
+    if (process.platform === 'win32') {
+      return `${command}.cmd`;
+    }
+
+    return command;
   }
 
   private runCommand(command: string, args: string[]) {


### PR DESCRIPTION
## Summary
- make the update command runner resolve npm.cmd on Windows hosts
- keep update logs displaying the original command names for readability

## Testing
- npm install *(fails: 403 Forbidden due to registry access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68e5f3c1cdf0832f9b1f23e722bfcaac